### PR TITLE
Fixed further shenanigans

### DIFF
--- a/LeaderboardCore/UI/ViewControllers/LeaderboardNavigationButtonsController.cs
+++ b/LeaderboardCore/UI/ViewControllers/LeaderboardNavigationButtonsController.cs
@@ -246,12 +246,15 @@ namespace LeaderboardCore.UI.ViewControllers
 
             if (!leaderboardLoaded)
             {
+                NotifyPropertyChanged(nameof(LeftButtonActive));
+                NotifyPropertyChanged(nameof(RightButtonActive));
                 return;
             }
-            
-            if (pluginConfig.LastLeaderboard != null && !customLeaderboardsById.ContainsKey(pluginConfig.LastLeaderboard) && currentIndex != 0)
+
+            if (ShowDefaultLeaderboard || (pluginConfig.LastLeaderboard != null && !customLeaderboardsById.ContainsKey(pluginConfig.LastLeaderboard) && currentIndex != 0))
             {
                 SwitchToDefault(lastLeaderboard);
+                
                 if (!ShowDefaultLeaderboard && customLeaderboardsById.Count > 0)
                 {
                     RightButtonClick(lastLeaderboard);

--- a/LeaderboardCore/UI/ViewControllers/LeaderboardNavigationButtonsController.cs
+++ b/LeaderboardCore/UI/ViewControllers/LeaderboardNavigationButtonsController.cs
@@ -244,6 +244,11 @@ namespace LeaderboardCore.UI.ViewControllers
                 this.customLeaderboardsById[customLeaderboard.Key] = customLeaderboard.Value;
             }
 
+            if (!leaderboardLoaded)
+            {
+                return;
+            }
+            
             if (pluginConfig.LastLeaderboard != null && !customLeaderboardsById.ContainsKey(pluginConfig.LastLeaderboard) && currentIndex != 0)
             {
                 SwitchToDefault(lastLeaderboard);


### PR DESCRIPTION
Fixed leaderboards first being loaded in the wrong position and fixed the default leaderboard not being switched to when ScoreSaber is uninstalled