### PR TITLE
Fix navigation issues

### DIFF
--- a/LeaderboardCore/Managers/CustomLeaderboardManager.cs
+++ b/LeaderboardCore/Managers/CustomLeaderboardManager.cs
@@ -1,8 +1,6 @@
 ﻿using LeaderboardCore.Interfaces;
 using LeaderboardCore.Models;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Linq;
 using System.Reflection;
 
 namespace LeaderboardCore.Managers
@@ -31,7 +29,7 @@ namespace LeaderboardCore.Managers
             {
                 customLeaderboard.pluginId = Assembly.GetCallingAssembly().GetName().Name;
             }
-            
+
             if (!customLeaderboardsById.ContainsKey(customLeaderboard.LeaderboardId))
             {
                 customLeaderboardsById[customLeaderboard.LeaderboardId] = customLeaderboard;
@@ -45,8 +43,10 @@ namespace LeaderboardCore.Managers
         /// </summary>
         public void Unregister(CustomLeaderboard customLeaderboard)
         {
-            customLeaderboardsById.Remove(customLeaderboard.LeaderboardId);
-            OnLeaderboardsChanged();
+            if (customLeaderboardsById.Remove(customLeaderboard.LeaderboardId))
+            {
+                OnLeaderboardsChanged();
+            }
         }
 
         private void OnLeaderboardsChanged()

--- a/LeaderboardCore/Managers/CustomLeaderboardManager.cs
+++ b/LeaderboardCore/Managers/CustomLeaderboardManager.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 namespace LeaderboardCore.Managers
 {
     /// <summary>
-    /// Class for the Leaderboard Manager. Use it to register and unregister yourself. Requires Zenject to recieve the instance (installed in menu scene).
+    /// Class for the Leaderboard Manager. Use it to register and unregister yourself. Requires Zenject to receive the instance (installed in menu scene).
     /// </summary>
     public class CustomLeaderboardManager
     {

--- a/LeaderboardCore/Managers/MultiplayerLeaderboardManager.cs
+++ b/LeaderboardCore/Managers/MultiplayerLeaderboardManager.cs
@@ -34,16 +34,16 @@ namespace LeaderboardCore.Managers
 			}
 
 			_platformLeaderboardViewController.SetData(_levelSelectionNavigationController.selectedDifficultyBeatmap);
-			
+
 			_mainFlowCoordinator.YoungestChildFlowCoordinatorOrSelf().InvokeMethod<object, FlowCoordinator>("SetRightScreenViewController", _platformLeaderboardViewController, ViewController.AnimationType.In);
-			_serverPlayerListViewController.gameObject.SetActive(false);
+			_serverPlayerListViewController.DeactivateGameObject();
 		}
 
 		private void HideLeaderboard()
 		{
 			_mainFlowCoordinator.YoungestChildFlowCoordinatorOrSelf().InvokeMethod<object, FlowCoordinator>("SetRightScreenViewController", null, ViewController.AnimationType.Out);
 		}
-		
+
 		private void LevelSelectionNavigationControllerOndidChangeLevelDetailContentEvent(LevelSelectionNavigationController levelSelectionNavigationController, StandardLevelDetailViewController.ContentType contentType)
 		{
 			if (contentType == StandardLevelDetailViewController.ContentType.OwnedAndReady)
@@ -51,7 +51,7 @@ namespace LeaderboardCore.Managers
 				ShowLeaderboard(levelSelectionNavigationController.selectedDifficultyBeatmap);
 				return;
 			}
-			
+
 			ShowLeaderboard(null);
 		}
 
@@ -65,7 +65,7 @@ namespace LeaderboardCore.Managers
 			_levelSelectionNavigationController.didChangeDifficultyBeatmapEvent += LevelSelectionNavigationControllerOndidChangeDifficultyBeatmapEvent;
 			_levelSelectionNavigationController.didChangeLevelDetailContentEvent += LevelSelectionNavigationControllerOndidChangeLevelDetailContentEvent;
 		}
-		
+
 		public void Dispose()
 		{
 			_levelSelectionNavigationController.didChangeDifficultyBeatmapEvent -= LevelSelectionNavigationControllerOndidChangeDifficultyBeatmapEvent;

--- a/LeaderboardCore/Models/CustomLeaderboard.cs
+++ b/LeaderboardCore/Models/CustomLeaderboard.cs
@@ -40,7 +40,7 @@ namespace LeaderboardCore.Models
 
             if (!panelScreen.isActiveAndEnabled)
             {
-                SharedCoroutineStarter.Instance.StartCoroutine(WaitForScreen(panelScreen, leaderboardPosition,
+                SharedCoroutineStarter.instance.StartCoroutine(WaitForScreen(panelScreen, leaderboardPosition,
                     platformLeaderboardViewController));
                 return;
             }

--- a/LeaderboardCore/Models/CustomLeaderboard.cs
+++ b/LeaderboardCore/Models/CustomLeaderboard.cs
@@ -94,7 +94,7 @@ namespace LeaderboardCore.Models
                 }
             }
 
-            if (leaderboardViewController != null && leaderboardViewController.isActivated)
+            if (leaderboardViewController != null)
             {
                 leaderboardViewController.__Deactivate(false, true, false);
             }

--- a/LeaderboardCore/Models/CustomLeaderboard.cs
+++ b/LeaderboardCore/Models/CustomLeaderboard.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using BeatSaberMarkupLanguage.FloatingScreen;
 using HMUI;
 using LeaderboardCore.Utilities;
@@ -21,28 +20,31 @@ namespace LeaderboardCore.Models
         /// The ViewController for the leaderboard itself.
         /// </summary>
         protected abstract ViewController leaderboardViewController { get; }
-        
+
         /// <summary>
         /// The ID for the leaderboard.
         /// Must be a unique string if the mod has multiple leaderboards.
         /// </summary>
         protected virtual string leaderboardId { get; } = "";
-        
+
         internal string pluginId;
-        
+
         internal string LeaderboardId => $"{pluginId}{leaderboardId}";
 
         internal void Show(FloatingScreen panelScreen, Vector3 leaderboardPosition, PlatformLeaderboardViewController platformLeaderboardViewController)
         {
-            panelScreen.gameObject.SetActive(true);
-            
+            if (!panelScreen.gameObject.activeSelf)
+            {
+                panelScreen.gameObject.SetActive(true);
+            }
+
             if (!panelScreen.isActiveAndEnabled)
             {
                 SharedCoroutineStarter.Instance.StartCoroutine(WaitForScreen(panelScreen, leaderboardPosition,
                     platformLeaderboardViewController));
                 return;
             }
-            
+
             if (panelViewController != null)
             {
                 panelScreen.SetRootViewController(panelViewController, ViewController.AnimationType.None);
@@ -69,7 +71,7 @@ namespace LeaderboardCore.Models
                 leaderboardViewController.transform.SetParent(platformLeaderboardViewController.transform);
             }
         }
-        
+
         private IEnumerator WaitForScreen(FloatingScreen panelScreen, Vector3 leaderboardPosition,
             PlatformLeaderboardViewController platformLeaderboardViewController)
         {
@@ -90,7 +92,7 @@ namespace LeaderboardCore.Models
                 }
                 else
                 {
-                    panelViewController.gameObject.SetActive(false);
+                    panelViewController.DeactivateGameObject();
                 }
             }
 

--- a/LeaderboardCore/Models/ScoreSaberCustomLeaderboard.cs
+++ b/LeaderboardCore/Models/ScoreSaberCustomLeaderboard.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using LeaderboardCore.Interfaces;
+﻿using LeaderboardCore.Interfaces;
 using UnityEngine;
 using Zenject;
 
@@ -15,9 +14,13 @@ namespace LeaderboardCore.Models
 
         private Transform ssPanelScreenTransform;
         private Vector3 ssPanelScreenPosition;
-        
+
+        private Vector3 hiddenPosition;
+
         public void OnScoreSaberActivated()
         {
+            hiddenPosition = new Vector3(-999, -999, -999);
+
             if (ssLeaderboardElementsTransform == null)
             {
                 ssLeaderboardElementsTransform = platformLeaderboardViewController.transform.Find("ScoreSaberLeaderboardElements");
@@ -30,19 +33,19 @@ namespace LeaderboardCore.Models
                 ssPanelScreenPosition = ssPanelScreenTransform.localPosition;
             }
         }
-        
+
         public void YeetSS()
         {
-            if (ssLeaderboardElementsTransform != null && ssPanelScreenTransform != null)
+            if (ssLeaderboardElementsTransform != null && ssPanelScreenTransform != null && ssLeaderboardElementsTransform.localPosition != hiddenPosition)
             {
-                ssLeaderboardElementsTransform.localPosition = new Vector3(-999, -999);
-                ssPanelScreenTransform.localPosition = new Vector3(-999, -999);
+                ssLeaderboardElementsTransform.localPosition = hiddenPosition;
+                ssPanelScreenTransform.localPosition = hiddenPosition;
             }
         }
 
         public void UnYeetSS()
         {
-            if (ssLeaderboardElementsTransform != null && ssPanelScreenTransform != null)
+            if (ssLeaderboardElementsTransform != null && ssPanelScreenTransform != null && ssLeaderboardElementsTransform.localPosition != ssLeaderboardElementsPosition)
             {
                 ssLeaderboardElementsTransform.localPosition = ssLeaderboardElementsPosition;
                 ssPanelScreenTransform.localPosition = ssPanelScreenPosition;

--- a/LeaderboardCore/UI/ViewControllers/LeaderboardNavigationButtonsController.cs
+++ b/LeaderboardCore/UI/ViewControllers/LeaderboardNavigationButtonsController.cs
@@ -146,7 +146,7 @@ namespace LeaderboardCore.UI.ViewControllers
 
         private void SwitchToIndex(int index, CustomLeaderboard? lastLeaderboard = null)
         {
-            if (index == 0 || index > orderedCustomLeaderboards.Count + 1)
+            if (index == 0 || index > orderedCustomLeaderboards.Count)
             {
                 SwitchToDefault(lastLeaderboard);
             }

--- a/LeaderboardCore/UI/ViewControllers/LeaderboardNavigationButtonsController.cs
+++ b/LeaderboardCore/UI/ViewControllers/LeaderboardNavigationButtonsController.cs
@@ -6,7 +6,6 @@ using LeaderboardCore.Interfaces;
 using LeaderboardCore.Models;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using LeaderboardCore.Configuration;
 using UnityEngine;
 using Zenject;
@@ -17,32 +16,33 @@ namespace LeaderboardCore.UI.ViewControllers
     [ViewDefinition("LeaderboardCore.UI.Views.LeaderboardNavigationButtons.bsml")]
     internal class LeaderboardNavigationButtonsController : BSMLAutomaticViewController, IInitializable, IDisposable, INotifyLeaderboardSet, INotifyLeaderboardLoad, INotifyCustomLeaderboardsChange
     {
-        [Inject] 
+        [Inject]
         private readonly PlatformLeaderboardViewController platformLeaderboardViewController = null!;
-        
+
         [Inject]
         private readonly PluginConfig pluginConfig = null!;
 
-        [InjectOptional] 
+        [InjectOptional]
         private readonly ScoreSaberCustomLeaderboard? scoreSaberCustomLeaderboard = null!;
-        
+
         private FloatingScreen? buttonsFloatingScreen;
         private FloatingScreen? customPanelFloatingScreen;
 
         private Transform? containerTransform;
         private Vector3 containerPosition;
-        
+        private Vector3 hiddenPosition;
+
         private bool leaderboardLoaded;
         private IPreviewBeatmapLevel? selectedLevel;
 
         private readonly List<CustomLeaderboard> orderedCustomLeaderboards = new List<CustomLeaderboard>();
         private readonly Dictionary<string, CustomLeaderboard> customLeaderboardsById = new Dictionary<string, CustomLeaderboard>();
         private int currentIndex;
-        
+
         public void Initialize()
         {
             buttonsFloatingScreen = FloatingScreen.CreateFloatingScreen(new Vector2(120f, 25f), false, Vector3.zero, Quaternion.identity);
-            
+
             var buttonsFloatingScreenTransform = buttonsFloatingScreen.transform;
             buttonsFloatingScreenTransform.SetParent(platformLeaderboardViewController.transform);
             buttonsFloatingScreenTransform.localPosition = new Vector3(3f, 50f);
@@ -64,7 +64,7 @@ namespace LeaderboardCore.UI.ViewControllers
             customFloatingScreenGO.SetActive(false);
             customFloatingScreenGO.SetActive(true);
             customFloatingScreenGO.name = "CustomLeaderboardPanel";
-            
+
             platformLeaderboardViewController.didActivateEvent += OnLeaderboardActivated;
         }
 
@@ -74,29 +74,30 @@ namespace LeaderboardCore.UI.ViewControllers
             {
                 Destroy(buttonsFloatingScreen.gameObject);
             }
-            
+
             platformLeaderboardViewController.didActivateEvent -= OnLeaderboardActivated;
         }
 
         public void OnEnable()
         {
             OnLeaderboardLoaded();
-            
+
             if (containerTransform == null)
             {
                 containerTransform = platformLeaderboardViewController.transform.Find("Container");
                 containerPosition = containerTransform.localPosition;
+                hiddenPosition = new Vector3(-999, -999, -999);
                 leaderboardLoaded = true;
                 OnLeaderboardLoaded();
             }
         }
-        
+
         private void OnLeaderboardActivated(bool firstactivation, bool addedtohierarchy, bool screensystemenabling)
         {
             platformLeaderboardViewController.didActivateEvent -= OnLeaderboardActivated;
             buttonsFloatingScreen!.SetRootViewController(this, AnimationType.None);
         }
-        
+
         public void OnLeaderboardSet(IDifficultyBeatmap difficultyBeatmap)
         {
             selectedLevel = difficultyBeatmap.level;
@@ -126,7 +127,7 @@ namespace LeaderboardCore.UI.ViewControllers
                 else if (currentIndex == 0 && !ShowDefaultLeaderboard)
                 {
                     RightButtonClick();
-                }   
+                }
             }
 
             NotifyPropertyChanged(nameof(LeftButtonActive));
@@ -155,7 +156,7 @@ namespace LeaderboardCore.UI.ViewControllers
                     ? outLastLeaderboard
                     : null;
                 lastLeaderboard?.Hide(customPanelFloatingScreen);
-                
+
                 currentIndex = index;
                 var currentLeaderboard = orderedCustomLeaderboards[currentIndex - 1];
                 pluginConfig.LastLeaderboard = currentLeaderboard.LeaderboardId;
@@ -170,22 +171,22 @@ namespace LeaderboardCore.UI.ViewControllers
                 var lastLeaderboardIndex = orderedCustomLeaderboards.IndexOf(lastLeaderboard);
                 lastLeaderboard.Show(customPanelFloatingScreen, containerPosition, platformLeaderboardViewController);
                 currentIndex = lastLeaderboardIndex + 1;
-                YeetDefault();             
+                YeetDefault();
             }
         }
 
         private void YeetDefault()
         {
-            if (containerTransform != null)
+            if (containerTransform != null && containerTransform.localPosition != hiddenPosition)
             {
-                containerTransform.localPosition = new Vector3(-999, -999);
+                containerTransform.localPosition = hiddenPosition;
             }
             scoreSaberCustomLeaderboard?.YeetSS();
         }
 
         private void UnYeetDefault()
         {
-            if (containerTransform != null)
+            if (containerTransform != null && containerTransform.localPosition != containerPosition)
             {
                 containerTransform.localPosition = containerPosition;
             }
@@ -199,12 +200,12 @@ namespace LeaderboardCore.UI.ViewControllers
             {
                 return;
             }
-            
+
             if (customLeaderboardsById.TryGetValue(pluginConfig.LastLeaderboard, out var outLastLeaderboard))
             {
                 outLastLeaderboard.Hide(customPanelFloatingScreen);
             }
-            
+
             currentIndex--;
 
             if (currentIndex == 0)
@@ -251,19 +252,19 @@ namespace LeaderboardCore.UI.ViewControllers
 
         public void OnLeaderboardsChanged(IEnumerable<CustomLeaderboard> orderedCustomLeaderboards, Dictionary<string, CustomLeaderboard> customLeaderboardsById)
         {
-            this.orderedCustomLeaderboards.Clear(); 
+            this.orderedCustomLeaderboards.Clear();
             this.orderedCustomLeaderboards.AddRange(orderedCustomLeaderboards);
-            
+
             // I hate how this library is so scuffed and really hope scoresaber uses it instead of having to do this
             // So this piece of scuffed code takes the last leaderboard if it was part of the current list and gives it for switching out
             var lastLeaderboard = this.customLeaderboardsById.TryGetValue(pluginConfig.LastLeaderboard ?? "", out var outLastLeaderboard) ? outLastLeaderboard : null;
-            
+
             this.customLeaderboardsById.Clear();
             foreach (var customLeaderboard in customLeaderboardsById)
             {
                 this.customLeaderboardsById[customLeaderboard.Key] = customLeaderboard.Value;
             }
-            
+
             if (!leaderboardLoaded)
                 return;
 
@@ -294,7 +295,7 @@ namespace LeaderboardCore.UI.ViewControllers
 
         [UIValue("right-button-active")]
         private bool RightButtonActive => currentIndex < orderedCustomLeaderboards.Count && selectedLevel is CustomPreviewBeatmapLevel;
-        
+
         private bool ShowDefaultLeaderboard => scoreSaberCustomLeaderboard != null || !(selectedLevel is CustomPreviewBeatmapLevel) || orderedCustomLeaderboards.Count == 0;
     }
 }

--- a/LeaderboardCore/UI/ViewControllers/LeaderboardNavigationButtonsController.cs
+++ b/LeaderboardCore/UI/ViewControllers/LeaderboardNavigationButtonsController.cs
@@ -32,7 +32,6 @@ namespace LeaderboardCore.UI.ViewControllers
         private Vector3 containerPosition;
         private Vector3 hiddenPosition;
 
-        private bool leaderboardLoaded;
         private IPreviewBeatmapLevel? selectedLevel;
 
         private readonly List<CustomLeaderboard> orderedCustomLeaderboards = new List<CustomLeaderboard>();
@@ -80,14 +79,15 @@ namespace LeaderboardCore.UI.ViewControllers
 
         public void OnEnable()
         {
-            OnLeaderboardLoaded();
-
             if (containerTransform == null)
             {
                 containerTransform = platformLeaderboardViewController.transform.Find("Container");
                 containerPosition = containerTransform.localPosition;
                 hiddenPosition = new Vector3(-999, -999, -999);
-                leaderboardLoaded = true;
+            }
+
+            if (!isActivated)
+            {
                 OnLeaderboardLoaded();
             }
         }
@@ -106,7 +106,7 @@ namespace LeaderboardCore.UI.ViewControllers
 
         public void OnLeaderboardLoaded(bool loaded = true)
         {
-            if (!leaderboardLoaded)
+            if (!isActiveAndEnabled && !isActivated)
                 return;
 
             if (!(selectedLevel is CustomPreviewBeatmapLevel))
@@ -136,12 +136,16 @@ namespace LeaderboardCore.UI.ViewControllers
 
         private void SwitchToDefault(CustomLeaderboard? lastLeaderboard = null)
         {
-            lastLeaderboard ??= customLeaderboardsById.TryGetValue(pluginConfig.LastLeaderboard ?? "", out var outLastLeaderboard)
-                ? outLastLeaderboard
-                : null;
-            lastLeaderboard?.Hide(customPanelFloatingScreen);
+            if (containerTransform != null && containerTransform.localPosition == hiddenPosition)
+            {
+                lastLeaderboard ??= customLeaderboardsById.TryGetValue(pluginConfig.LastLeaderboard ?? "", out var outLastLeaderboard)
+                    ? outLastLeaderboard
+                    : null;
+                lastLeaderboard?.Hide(customPanelFloatingScreen);
+                UnYeetDefault();
+            }
+
             currentIndex = 0;
-            UnYeetDefault();
         }
 
         private void SwitchToIndex(int index, CustomLeaderboard? lastLeaderboard = null)
@@ -265,7 +269,7 @@ namespace LeaderboardCore.UI.ViewControllers
                 this.customLeaderboardsById[customLeaderboard.Key] = customLeaderboard.Value;
             }
 
-            if (!leaderboardLoaded)
+            if (!isActiveAndEnabled && !isActivated)
                 return;
 
             // We only want to display the default leaderboard if there's no other custom leaderboards

--- a/LeaderboardCore/Utilities/SharedCoroutineStarter.cs
+++ b/LeaderboardCore/Utilities/SharedCoroutineStarter.cs
@@ -2,12 +2,57 @@
 
 namespace LeaderboardCore.Utilities
 {
-	public class SharedCoroutineStarter : MonoBehaviour {
-		static MonoBehaviour _instance = null;
-		public static MonoBehaviour Instance => _instance ??= new GameObject().AddComponent<SharedCoroutineStarter>();
+    // Mostly a copy-paste of PersistentSingleton<T> from game version < 1.31.0.
+    internal class SharedCoroutineStarter : MonoBehaviour
+    {
+        private static SharedCoroutineStarter? _instance;
+        private static object _lock = new object();
+        private static bool _applicationIsQuitting;
 
-		void Awake() {
-			DontDestroyOnLoad(gameObject);
-		}
-	}
+        public static SharedCoroutineStarter instance
+        {
+            get
+            {
+                if (_applicationIsQuitting)
+                {
+                    Debug.LogWarning("[Singleton] Instance '" + nameof(SharedCoroutineStarter) + "' already destroyed on application quit. Won't create again - returning null.");
+                    return null;
+                }
+
+                lock (_lock)
+                {
+                    if (_instance == null)
+                    {
+                        _instance = FindObjectOfType<SharedCoroutineStarter>();
+
+                        if (FindObjectsOfType<SharedCoroutineStarter>().Length > 1)
+                        {
+                            Debug.LogError("[Singleton] Something went really wrong - there should never be more than 1 singleton! Reopening the scene might fix it.");
+                            return _instance;
+                        }
+
+                        if (_instance == null)
+                        {
+                            GameObject obj = new GameObject();
+                            _instance = obj.AddComponent<SharedCoroutineStarter>();
+                            obj.name = nameof(SharedCoroutineStarter);
+                            DontDestroyOnLoad(obj);
+                        }
+                    }
+
+                    return _instance;
+                }
+            }
+        }
+
+        protected void OnEnable()
+        {
+            DontDestroyOnLoad(this);
+        }
+
+        protected virtual void OnDestroy()
+        {
+            _applicationIsQuitting = true;
+        }
+    }
 }

--- a/LeaderboardCore/manifest.json
+++ b/LeaderboardCore/manifest.json
@@ -3,7 +3,7 @@
     "id": "LeaderboardCore",
     "name": "LeaderboardCore",
     "author": "PixelBoom & PulseLane & Sirspam",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "A utility for custom leaderboards to attach themselves in Beat Saber.",
     "gameVersion": "1.31.0",
     "dependsOn": {


### PR DESCRIPTION
This will hopefully fix the remaining navigation issues. 

It's an attempt to fix the issue addressed by commits d2fcf58 and 688fed3. 

Both issues were caused by `OnLeaderboardsChanged` calls, which resulted in a selection of the last active leaderboard instead of the default leaderboard.

Hitbloq was unregistering itself whenever an OST was selected, resulting in double `SwitchToDefault` calls and `OnLeaderboardsChanged` being fired incorrectly.

